### PR TITLE
Added support for tenantName

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,8 +29,13 @@ function authenticate(options, cb) {
       'an API key is required!');
   }
 
-  if (options.tenantId) {
+  if (options.tenantId && options.tenantName) {
+    throw new Error('[simple-keystone-client:badoptions] TenantName' +
+        'and tenantId cannot be specified together.');
+  } else if (options.tenantId) {
     auth.tenantId = options.tenantId;
+  } else if (options.tenantName) {
+    auth.tenantName = options.tenantName;
   }
 
   request({

--- a/test/client.js
+++ b/test/client.js
@@ -105,6 +105,48 @@ describe('client.authenticate', function () {
     });
   });
 
+  it('sends the tenantName if present', function (done) {
+    var scope;
+
+    scope = nock('https://identity.api.rackspacecloud.com')
+      .post('/v2.0/tokens', {
+        auth: {
+          'RAX-KSKEY:apiKeyCredentials': {
+            username: 'test.user',
+            apiKey: 'deadbeefdeadbeefdeadbeefdeadbeef'
+          },
+          tenantName: 'foobar'
+        }
+      })
+      .reply(200, { access: { token: 'WOOO!' } });
+
+    client.authenticate({
+      username: 'test.user',
+      apiKey: 'deadbeefdeadbeefdeadbeefdeadbeef',
+      tenantName: 'foobar'
+    }, function (err) {
+      if (err) {
+        return done(err);
+      }
+      scope.done();
+      done();
+    });
+  });
+
+  it('throws an error when both tenant id and tenant name are supplied',
+    function () {
+      expect(function () {
+        client.authenticate({
+        username: 'test.user',
+        apiKey: 'deadbeefdeadbeefdeadbeefdeadbeef',
+        tenantName: 'foobar',
+        tenantId: '123456'
+      }, noop);
+      }).to.throw('[simple-keystone-client:badoptions] TenantName' +
+        'and tenantId cannot be specified together.');
+    }
+  );
+
   it('propagates authentication failures', function (done) {
     var scope = nock('https://identity.api.rackspacecloud.com')
       .post('/v2.0/tokens')


### PR DESCRIPTION
Added keystone support for tenantName.

tenantName (Optional)   plain   xsd:string  
The tenant name. Both the tenantId and tenantName attributes are optional, but should not be specified together. If both attributes are specified, the server responds with a 400 Bad Request.

http://developer.openstack.org/api-ref-identity-v2.html
